### PR TITLE
Replace {{field}} interpolate value with ng-bind directive

### DIFF
--- a/app/scripts/directives/field-directive.js
+++ b/app/scripts/directives/field-directive.js
@@ -40,7 +40,7 @@ angularApp.directive('fieldDirective', function($http, $compile) {
     }
 
     return {
-        template: '<div>{{field}}</div>',
+        template: '<div ng-bind="field"></div>',
         restrict: 'E',
         scope: {
             field: '='


### PR DESCRIPTION
Removes the flashing of the full json field object.