### PR TITLE
Add support for ng-cloak

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -73,3 +73,7 @@ body {
   color:red;
   font-size: smaller;
 }
+
+[ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
+  display: none !important;
+}


### PR DESCRIPTION
Since Angular is being loaded in the footer, it is essential to include this CSS directive in the styles so ng-cloak can be effective.
