### PR TITLE
Add ng-cloak directive

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -12,7 +12,7 @@
 	<!-- endbuild -->
 
   </head>
-  <body ng-app="angularjsFormBuilderApp">
+  <body ng-app="angularjsFormBuilderApp" ng-cloak>
         <div class="container-narrow">
             <div class="masthead" ng-controller="HeaderCtrl" >
                 <ul class="nav nav-pills pull-right">


### PR DESCRIPTION
Prevent the Angular html template from being briefly displayed by the browser in its raw (uncompiled) form the page is loading. This prevents the undesirable flicker effect, especially visible on the 'View Example form' template
